### PR TITLE
Refactoring lib/facter/vmware_version.rb

### DIFF
--- a/lib/facter/vmware_version.rb
+++ b/lib/facter/vmware_version.rb
@@ -27,18 +27,10 @@ Facter.add('vmware_version') do
     setcode {
         biosinformation = Facter::Util::Resolution.exec("dmidecode -t bios | grep -A4 'BIOS Information'")
         if !biosinformation.nil?
-            if biosinformation =~ /Address: (0x.*)/i
-                biosaddress = $1
-            else
-                biosaddress = 'no_data'
-            end
+            biosaddress = (biosinformation =~ /Address: (0x.*)/i) ? $1 : 'no_data'
 
             # The BIOS release date is currently unused. Uncomment if needed.
-            #if biosinformation =~ /Release Date: (.*)/i
-            #    biosdate = $1
-            #else
-            #    biosdate = 'no_data'
-            #end
+            #biosdate = (biosinformation =~ /Release Date: (.*)/i) ? $1 : 'no_data'
 
             # Return either a known version, or a constructed unknown version.
             biosaddresses.fetch(biosaddress, "unknown-#{biosaddress}")

--- a/lib/facter/vmware_version.rb
+++ b/lib/facter/vmware_version.rb
@@ -24,25 +24,21 @@ Facter.add('vmware_version') do
     confine :kernel => 'Linux'
     confine :virtual => :vmware
     setcode {
-        hasdmidecode = Facter::Util::Resolution.exec('which dmidecode')
-        if !hasdmidecode.nil?
-            biosinformation = Facter::Util::Resolution.exec("#{hasdmidecode} -t bios | grep -A4 'BIOS Information'")
-            if !biosinformation.nil?
-
-                if biosinformation.include? 'Address: 0x'
-                    biosaddress = biosinformation.match(/Address: (0x.*)/i)[1]
-                else
-                    biosaddress = 'no_data'
-                end
-                if biosinformation.include? 'Release Date:'
-                    biosdate = biosinformation.match(/Release Date: (.*)/i)[1]
-                else
-                    biosdate = 'no_data'
-                end
-
-                # Return either a known version, or a constructed unknown version.
-                biosaddresses.fetch(biosaddress, "unknown-#{biosaddress}")
+        biosinformation = Facter::Util::Resolution.exec("dmidecode -t bios | grep -A4 'BIOS Information'")
+        if !biosinformation.nil?
+            if biosinformation.include? 'Address: 0x'
+                biosaddress = biosinformation.match(/Address: (0x.*)/i)[1]
+            else
+                biosaddress = 'no_data'
             end
+            if biosinformation.include? 'Release Date:'
+                biosdate = biosinformation.match(/Release Date: (.*)/i)[1]
+            else
+                biosdate = 'no_data'
+            end
+
+            # Return either a known version, or a constructed unknown version.
+            biosaddresses.fetch(biosaddress, "unknown-#{biosaddress}")
         end
     }
 end

--- a/lib/facter/vmware_version.rb
+++ b/lib/facter/vmware_version.rb
@@ -18,6 +18,7 @@ biosaddresses = {
             '0xEA520' => '6.7',
 }
 
+# TODO: Verify this is required for the confine to work correctly.
 Facter.loadfacts()
 
 Facter.add('vmware_version') do

--- a/lib/facter/vmware_version.rb
+++ b/lib/facter/vmware_version.rb
@@ -27,15 +27,15 @@ Facter.add('vmware_version') do
     setcode {
         biosinformation = Facter::Util::Resolution.exec("dmidecode -t bios | grep -A4 'BIOS Information'")
         if !biosinformation.nil?
-            if biosinformation.include? 'Address: 0x'
-                biosaddress = biosinformation.match(/Address: (0x.*)/i)[1]
+            if biosinformation =~ /Address: (0x.*)/i
+                biosaddress = $1
             else
                 biosaddress = 'no_data'
             end
 
             # The BIOS release date is currently unused. Uncomment if needed.
-            #if biosinformation.include? 'Release Date:'
-            #    biosdate = biosinformation.match(/Release Date: (.*)/i)[1]
+            #if biosinformation =~ /Release Date: (.*)/i
+            #    biosdate = $1
             #else
             #    biosdate = 'no_data'
             #end

--- a/lib/facter/vmware_version.rb
+++ b/lib/facter/vmware_version.rb
@@ -20,7 +20,7 @@ if Facter.value(:kernel) == 'Linux'
             end
 
             if biosaddress == 'no_data'
-                vmversion = ['unknown-',biosaddress].join('')
+                vmversion = "unknown-#{biosaddress}"
 #           Numbers from a prior life, which have only anecdotal proof.  Uncomment if you wish
 #            elsif biosaddress == '0xE8480'
 #                vmversion = '2.5'
@@ -51,7 +51,7 @@ if Facter.value(:kernel) == 'Linux'
             elsif biosaddress == '0xEA520'
                 vmversion = '6.7'
             else
-                vmversion = ['unknown-',biosaddress].join('')
+                vmversion = "unknown-#{biosaddress}"
             end
 
             Facter.add('vmware_version') do

--- a/lib/facter/vmware_version.rb
+++ b/lib/facter/vmware_version.rb
@@ -32,11 +32,13 @@ Facter.add('vmware_version') do
             else
                 biosaddress = 'no_data'
             end
-            if biosinformation.include? 'Release Date:'
-                biosdate = biosinformation.match(/Release Date: (.*)/i)[1]
-            else
-                biosdate = 'no_data'
-            end
+
+            # The BIOS release date is currently unused. Uncomment if needed.
+            #if biosinformation.include? 'Release Date:'
+            #    biosdate = biosinformation.match(/Release Date: (.*)/i)[1]
+            #else
+            #    biosdate = 'no_data'
+            #end
 
             # Return either a known version, or a constructed unknown version.
             biosaddresses.fetch(biosaddress, "unknown-#{biosaddress}")

--- a/lib/facter/vmware_version.rb
+++ b/lib/facter/vmware_version.rb
@@ -1,5 +1,23 @@
 require 'facter'
 
+biosaddresses = {
+#           Numbers from a prior life, which have only anecdotal proof.  Uncomment if you wish
+#            '0xE8480' => '2.5',
+#            '0xE7C70' => '3.0',
+#            '0xE7910' => '3.5',
+            '0xEA550' => '4.0',
+            '0xEA2E0' => '4.1',
+            '0xE72C0' => '5.0',
+            '0xEA0C0' => '5.1',
+            '0xE9AB0' => '5.1',
+            '0xEA050' => '5.5',
+            '0xE9FE0' => '5.5',
+            '0xE9A40' => '6.0',
+            '0xE99E0' => '6.0',
+            '0xEA580' => '6.5',
+            '0xEA520' => '6.7',
+}
+
 if Facter.value(:kernel) == 'Linux'
     Facter.loadfacts()
     
@@ -19,40 +37,8 @@ if Facter.value(:kernel) == 'Linux'
                 biosdate = 'no_data'
             end
 
-            if biosaddress == 'no_data'
-                vmversion = "unknown-#{biosaddress}"
-#           Numbers from a prior life, which have only anecdotal proof.  Uncomment if you wish
-#            elsif biosaddress == '0xE8480'
-#                vmversion = '2.5'
-#            elsif biosaddress == '0xE7C70'
-#                vmversion = '3.0'
-#            elsif biosaddress == '0xE7910'
-#                vmversion = '3.5'
-            elsif biosaddress == '0xEA550'
-                vmversion = '4.0'
-            elsif biosaddress == '0xEA2E0'
-                vmversion = '4.1'
-            elsif biosaddress == '0xE72C0'
-                vmversion = '5.0'
-            elsif biosaddress == '0xEA0C0'
-                vmversion = '5.1'
-            elsif biosaddress == '0xE9AB0'
-                vmversion = '5.1'
-            elsif biosaddress == '0xEA050'
-                vmversion = '5.5'
-            elsif biosaddress == '0xE9FE0'
-                vmversion = '5.5'
-            elsif biosaddress == '0xE9A40'
-                vmversion = '6.0'
-            elsif biosaddress == '0xE99E0'
-                vmversion = '6.0'
-            elsif biosaddress == '0xEA580'
-                vmversion = '6.5'
-            elsif biosaddress == '0xEA520'
-                vmversion = '6.7'
-            else
-                vmversion = "unknown-#{biosaddress}"
-            end
+            # Either it's a known version, or it's unknown (including 'no_data')
+            vmversion = biosaddresses.fetch(biosaddress, "unknown-#{biosaddress}")
 
             Facter.add('vmware_version') do
                 confine :virtual => :vmware


### PR DESCRIPTION
This passes `ruby -c lib/facter/vmware_version.rb` after each commit, but I don't have a machine handy to test the actual fact on. I've submitted a string of commits rather than squashing them to permit bisect in case of any issues found in testing (which you should do, since I didn't).